### PR TITLE
fix: respect format props and default value (#2034)

### DIFF
--- a/packages/date-picker/src/date-picker.ts
+++ b/packages/date-picker/src/date-picker.ts
@@ -47,7 +47,6 @@ export default defineComponent({
   setup(props, ctx) {
     provide('ElPopperOptions', props.popperOptions)
     const commonPicker = ref(null)
-    const format = DEFAULT_FORMATS_DATEPICKER[props.type] || DEFAULT_FORMATS_DATE
     const refProps = {
       ...props,
       focus: () => {
@@ -55,15 +54,20 @@ export default defineComponent({
       },
     }
     ctx.expose(refProps)
-    return () => h(CommonPicker, {
-      format,
-      ...props, // allow format to be overwrite
-      type: props.type,
-      ref: commonPicker,
-      'onUpdate:modelValue': value => ctx.emit('update:modelValue', value),
-    },
-    {
-      default: scopedProps => h(getPanel(props.type), scopedProps),
-    })
+    return () => {
+      // since props always have all defined keys on it, {format, ...props} will always overwrite format
+      // pick props.format or provide default value here before spreading
+      const format = props.format ?? (DEFAULT_FORMATS_DATEPICKER[props.type] || DEFAULT_FORMATS_DATE)
+      return h(CommonPicker, {
+        ...props,
+        format,
+        type: props.type,
+        ref: commonPicker,
+        'onUpdate:modelValue': value => ctx.emit('update:modelValue', value),
+      },
+      {
+        default: scopedProps => h(getPanel(props.type), scopedProps),
+      })
+    }
   },
 })


### PR DESCRIPTION
* fix: respect format props and default value

Vue 3 props will always have all keys defined, regardless if users pass props when using the component.
So {format, ...props} will always overwrite the default format because props has format defined on it.
When users do not pass format, the code breaks.

* fix: null-coalescing operator(??) requires parens

* fix: capture reactivity

Please make sure these boxes are checked before submitting your PR, thank you!

* [x] Make sure you follow Element's contributing guide [English](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.en-US.md) | ([中文](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.zh-CN.md) | [Español](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.es.md) | [Français](https://github.com/element-plus/element-plus/blob/master/.github/CONTRIBUTING.fr-FR.md)).
* [x] Make sure you are merging your commits to `dev` branch.
* [x] Add some descriptions and refer to relative issues for your PR.
